### PR TITLE
28 layout para el panel de administración

### DIFF
--- a/resources/js/Components/Dashboard/MenuSection.vue
+++ b/resources/js/Components/Dashboard/MenuSection.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { ChevronRight } from 'lucide-vue-next'
+
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/Components/ui/collapsible'
+import {
+    SidebarGroup,
+    SidebarGroupLabel,
+    SidebarMenu,
+    SidebarMenuAction,
+    SidebarMenuButton,
+    SidebarMenuItem,
+    SidebarMenuSub,
+    SidebarMenuSubButton,
+    SidebarMenuSubItem,
+} from '@/Components/ui/sidebar'
+import { MenuItem } from '@/types/MenuItem'
+
+defineProps<{
+    label?: string
+    items: MenuItem[]
+}>()
+</script>
+
+<template>
+    <SidebarGroup>
+        <SidebarGroupLabel v-if="label">{{ label }}</SidebarGroupLabel>
+        <SidebarMenu>
+            <Collapsible
+                v-for="item in items"
+                :key="item.title"
+                as-child
+                :default-open="item.isActive"
+            >
+                <SidebarMenuItem>
+                    <SidebarMenuButton as-child :tooltip="item.title">
+                        <a :href="item.url">
+                            <component class="text-[#fb5607]" :is="item.icon" />
+                            <span class="font-semibold">{{ item.title }}</span>
+                        </a>
+                    </SidebarMenuButton>
+                    <template v-if="item.items?.length">
+                        <CollapsibleTrigger as-child>
+                            <SidebarMenuAction class="data-[state=open]:rotate-90">
+                                <ChevronRight class="text-[#fb5607]" />
+                                <span class="sr-only">Toggle</span>
+                            </SidebarMenuAction>
+                        </CollapsibleTrigger>
+                        <CollapsibleContent>
+                            <SidebarMenuSub>
+                                <SidebarMenuSubItem
+                                    v-for="subItem in item.items"
+                                    :key="subItem.title"
+                                >
+                                    <SidebarMenuSubButton as-child>
+                                        <a :href="subItem.url">
+                                            <span>{{ subItem.title }}</span>
+                                        </a>
+                                    </SidebarMenuSubButton>
+                                </SidebarMenuSubItem>
+                            </SidebarMenuSub>
+                        </CollapsibleContent>
+                    </template>
+                </SidebarMenuItem>
+            </Collapsible>
+        </SidebarMenu>
+    </SidebarGroup>
+</template>

--- a/resources/js/Components/Dashboard/NavUser.vue
+++ b/resources/js/Components/Dashboard/NavUser.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { BadgeCheck, Bell, ChevronsUpDown, CreditCard, LogOut, Sparkles } from 'lucide-vue-next'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/Components/ui/avatar'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/Components/ui/dropdown-menu'
+import {
+    SidebarMenu,
+    SidebarMenuButton,
+    SidebarMenuItem,
+    useSidebar,
+} from '@/Components/ui/sidebar'
+
+const user = {
+    name: 'Motoryctech',
+    email: 'm@example.com',
+    avatar: '/avatars/shadcn.jpg',
+}
+
+const { isMobile } = useSidebar()
+</script>
+
+<template>
+    <SidebarMenu>
+        <SidebarMenuItem>
+            <DropdownMenu>
+                <DropdownMenuTrigger as-child>
+                    <SidebarMenuButton
+                        size="lg"
+                        class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                    >
+                        <Avatar class="h-8 w-8 rounded-lg">
+                            <AvatarImage :src="user.avatar" :alt="user.name" />
+                            <AvatarFallback class="rounded-lg text-[#fb5607]"> CN </AvatarFallback>
+                        </Avatar>
+                        <div class="grid flex-1 text-left text-sm leading-tight">
+                            <span class="truncate font-semibold">{{ user.name }}</span>
+                            <span class="truncate text-xs">{{ user.email }}</span>
+                        </div>
+                        <ChevronsUpDown class="ml-auto size-4 text-[#fb5607]" />
+                    </SidebarMenuButton>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                    class="w-[--reka-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+                    :side="isMobile ? 'bottom' : 'right'"
+                    align="end"
+                    :side-offset="4"
+                >
+                    <DropdownMenuLabel class="p-0 font-normal">
+                        <div class="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                            <Avatar class="h-8 w-8 rounded-lg">
+                                <AvatarImage :src="user.avatar" :alt="user.name" />
+                                <AvatarFallback class="rounded-lg"> CN </AvatarFallback>
+                            </Avatar>
+                            <div class="grid flex-1 text-left text-sm leading-tight">
+                                <span class="truncate font-semibold">{{ user.name }}</span>
+                                <span class="truncate text-xs">{{ user.email }}</span>
+                            </div>
+                        </div>
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem>
+                            <Sparkles />
+                            Upgrade to Pro
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                        <DropdownMenuItem>
+                            <BadgeCheck />
+                            Account
+                        </DropdownMenuItem>
+                        <DropdownMenuItem>
+                            <CreditCard />
+                            Billing
+                        </DropdownMenuItem>
+                        <DropdownMenuItem>
+                            <Bell />
+                            Notifications
+                        </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem>
+                        <LogOut />
+                        Log out
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </SidebarMenuItem>
+    </SidebarMenu>
+</template>

--- a/resources/js/Components/Dashboard/Sidebar.vue
+++ b/resources/js/Components/Dashboard/Sidebar.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+
+import MenuSection from '@/Components/Dashboard/MenuSection.vue'
+import NavUser from '@/Components/Dashboard/NavUser.vue'
+import {
+    Sidebar,
+    SidebarContent,
+    SidebarFooter,
+    SidebarHeader,
+    SidebarMenu,
+    SidebarMenuButton,
+    SidebarMenuItem,
+    SidebarProps,
+} from '@/Components/ui/sidebar'
+import { employeeMenu, financeMenu, salesMenu, serviceOrderMenu } from '@/constants/sidebarMenus'
+
+const props = withDefaults(defineProps<SidebarProps>(), {
+    variant: 'inset',
+})
+
+const servideOrderMenuItems = serviceOrderMenu
+const financeMenuItems = financeMenu
+const salesMenuItems = salesMenu
+const employeeMenuItems = employeeMenu
+</script>
+
+<template>
+    <Sidebar v-bind="props">
+        <SidebarHeader>
+            <SidebarMenu>
+                <SidebarMenuItem>
+                    <SidebarMenuButton size="lg" as-child>
+                        <div class="flex items-center justify-center">
+                            <Icon icon="mdi:tools" class="text-2xl text-[#fb5607]" />
+                            <div class="text-xl font-black uppercase tracking-wide">
+                                <span> Motorcy</span>
+                                <span class="font-semibold text-[#fb5607]">tech </span>
+                            </div>
+                        </div>
+                    </SidebarMenuButton>
+                </SidebarMenuItem>
+            </SidebarMenu>
+        </SidebarHeader>
+        <SidebarContent>
+            <MenuSection label="Servicios" :items="servideOrderMenuItems" />
+            <MenuSection label="Finanzas" :items="financeMenuItems" />
+            <MenuSection label="Tienda" :items="salesMenuItems" />
+            <MenuSection label="Agenda" :items="employeeMenuItems" />
+        </SidebarContent>
+        <SidebarFooter>
+            <NavUser />
+        </SidebarFooter>
+    </Sidebar>
+</template>

--- a/resources/js/Layouts/DashboardLayout.vue
+++ b/resources/js/Layouts/DashboardLayout.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3'
+
+import { Icon } from '@iconify/vue'
+
+import Sidebar from '@/Components/Dashboard/Sidebar.vue'
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbLink,
+    BreadcrumbList,
+    BreadcrumbPage,
+    BreadcrumbSeparator,
+} from '@/Components/ui/breadcrumb'
+import { Button } from '@/Components/ui/button'
+import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/Components/ui/sidebar'
+import { isDark, toggleDarkMode } from '@/lib/darkMode'
+</script>
+
+<template>
+    <Head title="Dashboard" />
+
+    <SidebarProvider>
+        <Sidebar />
+        <SidebarInset>
+            <header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+                <SidebarTrigger class="-ml-1" />
+                <Separator orientation="vertical" class="mr-2 h-4" />
+                <Breadcrumb>
+                    <BreadcrumbList>
+                        <BreadcrumbItem class="hidden md:block">
+                            <BreadcrumbLink href="#"> Ordenes de Servicio </BreadcrumbLink>
+                        </BreadcrumbItem>
+                        <BreadcrumbSeparator class="hidden text-[#fb5607] md:block" />
+                        <BreadcrumbItem>
+                            <BreadcrumbPage>Registro</BreadcrumbPage>
+                        </BreadcrumbItem>
+                    </BreadcrumbList>
+                </Breadcrumb>
+                <Button
+                    variant="ghost"
+                    class="ml-auto rounded-md font-normal text-foreground transition-colors duration-300 focus:outline-none dark:text-gray-200"
+                    @click="toggleDarkMode"
+                >
+                    <Icon
+                        :icon="
+                            isDark
+                                ? 'line-md:moon-alt-to-sunny-outline-loop-transition'
+                                : 'line-md:sunny-outline-to-moon-loop-transition'
+                        "
+                    />
+                </Button>
+            </header>
+            <div class="flex flex-1 flex-col gap-4 px-4 py-10">
+                <slot></slot>
+            </div>
+        </SidebarInset>
+    </SidebarProvider>
+</template>

--- a/resources/js/Pages/Landing/Partials/Navbar.vue
+++ b/resources/js/Pages/Landing/Partials/Navbar.vue
@@ -1,20 +1,12 @@
 <script setup lang="ts">
-import { useDark, useToggle } from '@vueuse/core'
-
 import { onMounted, onUnmounted, ref } from 'vue'
-
-import { Button } from '@/Components/ui/button/index'
 
 import { Icon } from '@iconify/vue'
 
+import { Button } from '@/Components/ui/button/index'
+import { isDark, toggleDarkMode } from '@/lib/darkMode'
+
 const isScrolled = ref(false)
-
-const isDark = useDark({ selector: 'html' })
-const toggleDark = useToggle(isDark)
-
-function toggleDarkMode() {
-    toggleDark()
-}
 
 const menu = ['Inicio', 'Servicios', 'Seguimiento', 'Contacto']
 
@@ -35,7 +27,7 @@ onUnmounted(() => {
 
 <template>
     <div
-        class="hidden w-full items-center justify-between overflow-hidden bg-[#fb5607] px-4 py-2 text-sm text-white transition-all duration-300 ease-in-out  md:flex"
+        class="hidden w-full items-center justify-between overflow-hidden bg-[#fb5607] px-4 py-2 text-sm text-white transition-all duration-300 ease-in-out md:flex"
         :class="[isScrolled ? 'pointer-events-none opacity-0' : 'opacity-100']"
         :style="{ height: isScrolled ? '0px' : `${TOP_BAR_HEIGHT}px` }"
     >
@@ -76,7 +68,7 @@ onUnmounted(() => {
     <header
         :class="[
             'sticky left-0 top-0 z-50 w-full transition-all duration-300',
-            isScrolled ? 'bg-[#061222] dark:bg-[#fb5607] shadow-sm' : 'bg-[#061222]',
+            isScrolled ? 'bg-[#061222] shadow-sm dark:bg-[#fb5607]' : 'bg-[#061222]',
         ]"
     >
         <nav class="container mx-auto flex items-center px-4 py-4">
@@ -88,19 +80,21 @@ onUnmounted(() => {
                     <Icon
                         icon="mdi:tools"
                         class="text-3xl"
-                        :class="isScrolled ? 'text-[#fb5607] dark:text-[#061222]' : 'text-[#fb5607]'"
+                        :class="
+                            isScrolled ? 'text-[#fb5607] dark:text-[#061222]' : 'text-[#fb5607]'
+                        "
                     />
                 </transition>
                 <div class="text-2xl font-black uppercase tracking-wide">
                     <transition name="slide-left" appear>
-                        <span>
-                            Motorcy
-                        </span>
+                        <span> Motorcy </span>
                     </transition>
                     <transition name="slide-left" appear>
                         <span
                             class="font-semibold"
-                            :class="isScrolled ? 'text-[#fb5607] dark:text-[#061222]' : 'text-[#fb5607]'"
+                            :class="
+                                isScrolled ? 'text-[#fb5607] dark:text-[#061222]' : 'text-[#fb5607]'
+                            "
                         >
                             tech
                         </span>
@@ -108,14 +102,15 @@ onUnmounted(() => {
                 </div>
             </div>
 
-
             <ul class="hidden flex-grow justify-center space-x-6 md:flex">
                 <li v-for="item in menu" :key="item">
                     <a
                         href="#"
                         :class="[
-                            'transition-colors duration-300 text-lg hover:underline hover:decoration-[3px] hover:underline-offset-[10px]',
-                            isScrolled ? 'text-[#fefcf9] hover:decoration-[#fb5607] dark:hover:text-[#061222] dark:hover:decoration-[#061222]' : 'text-white hover:decoration-[#fb5607]',
+                            'text-lg transition-colors duration-300 hover:underline hover:decoration-[3px] hover:underline-offset-[10px]',
+                            isScrolled
+                                ? 'text-[#fefcf9] hover:decoration-[#fb5607] dark:hover:text-[#061222] dark:hover:decoration-[#061222]'
+                                : 'text-white hover:decoration-[#fb5607]',
                         ]"
                     >
                         {{ item }}
@@ -127,7 +122,7 @@ onUnmounted(() => {
                 class="ml-auto hidden rounded-md px-4 py-2 font-semibold transition duration-300 md:block"
                 :class="
                     isScrolled
-                        ? 'border border-[#fb5607] dark:border-white text-white hover:bg-[#fb5607]'
+                        ? 'border border-[#fb5607] text-white hover:bg-[#fb5607] dark:border-white'
                         : 'border border-[#fb5607] text-white hover:bg-[#fb5607] hover:text-[#fefcf9]'
                 "
             >

--- a/resources/js/constants/sidebarMenus.ts
+++ b/resources/js/constants/sidebarMenus.ts
@@ -1,0 +1,103 @@
+import {
+    AtSign,
+    BanknoteArrowDown,
+    BanknoteArrowUp,
+    Bike,
+    ChartNoAxesCombined,
+    ShoppingCart,
+    SquareTerminal,
+    Star,
+    Store,
+    UserCog,
+    Users,
+    Wrench,
+} from 'lucide-vue-next'
+
+export const serviceOrderMenu = [
+    {
+        title: 'Ordenes de Servicio',
+        url: '#',
+        icon: SquareTerminal,
+        isActive: true,
+        items: [
+            {
+                title: 'Registro',
+                url: '#',
+            },
+            {
+                title: 'Histórico',
+                url: '#',
+            },
+        ],
+    },
+    {
+        title: 'Clientes',
+        url: '#',
+        icon: Users,
+        isActive: true,
+        items: [
+            {
+                title: 'Listado',
+                url: '#',
+            },
+            {
+                title: 'Mensajes',
+                url: '#',
+            },
+        ],
+    },
+    {
+        title: 'Motocicletas',
+        url: '#',
+        icon: Bike,
+    },
+    {
+        title: 'Reseñas',
+        url: '#',
+        icon: Star,
+    },
+]
+
+export const financeMenu = [
+    {
+        title: 'Proyecciones',
+        url: '#',
+        icon: ChartNoAxesCombined,
+    },
+    {
+        title: 'Ganancias',
+        url: '#',
+        icon: BanknoteArrowUp,
+    },
+    {
+        title: 'Gastos',
+        url: '#',
+        icon: BanknoteArrowDown,
+    },
+]
+
+export const employeeMenu = [
+    {
+        title: 'Personal',
+        url: '#',
+        icon: UserCog,
+    },
+    {
+        title: 'Proveedores',
+        url: '#',
+        icon: Wrench,
+    },
+]
+
+export const salesMenu = [
+    {
+        title: 'Inventario',
+        url: '#',
+        icon: Store,
+    },
+    {
+        title: 'Ventas',
+        url: '#',
+        icon: ShoppingCart,
+    },
+]

--- a/resources/js/lib/darkMode.ts
+++ b/resources/js/lib/darkMode.ts
@@ -1,0 +1,8 @@
+import { useDark, useToggle } from '@vueuse/core'
+
+export const isDark = useDark({ selector: 'html' })
+const toggleDark = useToggle(isDark)
+
+export function toggleDarkMode() {
+    toggleDark()
+}

--- a/resources/js/types/MenuItem.ts
+++ b/resources/js/types/MenuItem.ts
@@ -1,0 +1,14 @@
+import type { LucideIcon } from 'lucide-vue-next'
+
+export interface MenuItem {
+    title: string
+    url: string
+    icon: LucideIcon
+    isActive?: boolean
+    items?: SubmenuItem[]
+}
+
+interface SubmenuItem {
+    title: string
+    url: string
+}


### PR DESCRIPTION
# Resumen
Se agregó la primera versión del layout para el panel de administración.

## Notas 
- Para agregar enlaces al menú lateral hay que modificar el archivo `resources/js/constants/sidebarMenus.ts` 
- Para utilizar el layout en la nueva vista hace falta importar el componente `import DashboardLayout from '@/Layouts/DashboardLayout.vue'` y agregar el contenido de la vista dentro del componente del layout:
```vue
<template>
    <DashboardLayout>
        <!-- Contenido -->
    </DashboardLayout>
</template>
```

Closes #28